### PR TITLE
feat: simplify build process and enforce C++11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+compile

--- a/build
+++ b/build
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-mkdir -p compile && cd compile
-cmake ../src -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=TRUE 
-make popf3-clp
+mkdir -p compile && cd compile || exit 1
+cmake -G "Unix Makefiles" ../src -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=TRUE 
+make popf3-clp -j"$(nproc)"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 2.4)
 
+set(CMAKE_CXX_STANDARD 11)
+
 if(COMMAND cmake_policy)
     cmake_policy(SET CMP0003 NEW)
 endif(COMMAND cmake_policy)


### PR DESCRIPTION
This PR introduces some tweaks to simplify the build process:
- Enforces C++11, which is still not default on some systems
- Speed up compilation specifying `nproc` when calling `make`
- Add `compile/` directory to `.gitignore`